### PR TITLE
Proper cabal-version is 2.0

### DIFF
--- a/streaming-bracketed.cabal
+++ b/streaming-bracketed.cabal
@@ -22,7 +22,7 @@ extra-source-files:
       ChangeLog.md
       .travis.yml
       .gitignore
-cabal-version:       2
+cabal-version:       2.0
 
 library
   exposed-modules:     


### PR DESCRIPTION
Future `cabal-install` versions we'll be more picky i.e. warn about this.

---

No need to make release just for this though.